### PR TITLE
[New reference genomes] Add Lyssavirus rabies

### DIFF
--- a/assembly/reference_genomes.tsv
+++ b/assembly/reference_genomes.tsv
@@ -344,3 +344,17 @@
 10497		African swine fever virus	NC_044952.1
 10497		African swine fever virus	NC_044953.1
 10497		African swine fever virus	NC_044954.1
+11292		Lyssavirus rabies	EF206707.1
+11292		Lyssavirus rabies	MG458319.1
+11292		Lyssavirus rabies	JQ685943.1
+11292		Lyssavirus rabies	KX148224.1
+11292		Lyssavirus rabies	KX148223.1
+11292		Lyssavirus rabies	KX148231.1
+11292		Lyssavirus rabies	JQ730682.1
+11292		Lyssavirus rabies	KX148266.1
+11292		Lyssavirus rabies	KX148245.1
+11292		Lyssavirus rabies	JQ685895.1
+11292		Lyssavirus rabies	JQ685952.1
+11292		Lyssavirus rabies	JQ685905.1
+11292		Lyssavirus rabies	JQ685901.1
+11292		Lyssavirus rabies	JQ685968.1


### PR DESCRIPTION
This PR adds 14 reference genomes for Lyssavirus rabies (TaxID 11292).
These are the same references utilized by [RefNAAP](https://github.com/jiangweiyao/RefNAAP/blob/main/Americas2.fasta)