### PR TITLE
Fix gcloud rsync exclude pattern regex error

### DIFF
--- a/.github/workflows/deploy-to-gcs.yml
+++ b/.github/workflows/deploy-to-gcs.yml
@@ -52,7 +52,7 @@ jobs:
           gcloud storage rsync . "gs://$GCS_BUCKET/$DEPLOY_PATH/" \
             --recursive \
             --delete-unmatched-destination-objects \
-            --exclude=".??*"
+            --exclude=".git*"
           echo "Deployment complete!"
 
       - name: Verify deployment


### PR DESCRIPTION
Fixes the deployment failure caused by an invalid regex pattern in the gcloud storage rsync exclude parameter.

## Problem
The deployment workflow failed with: ERROR: gcloud crashed (PatternError): multiple repeat at position 3

The pattern .??* creates an invalid regex with multiple consecutive repeat operators.

## Solution
Changed the exclude pattern from .??* to .git* which:
- Excludes .git/ and .github/ directories
- Uses a valid regex pattern
- Avoids potential issues with overly broad patterns

Fixes workflow run 21096588834