### PR TITLE
SECURITY: Deploy only specific files to prevent credential leaks

### DIFF
--- a/.github/workflows/deploy-to-gcs.yml
+++ b/.github/workflows/deploy-to-gcs.yml
@@ -48,11 +48,8 @@ jobs:
           GCS_BUCKET: viral-references
           DEPLOY_PATH: ${{ steps.deploy-path.outputs.path }}
         run: |
-          echo "Syncing to gs://$GCS_BUCKET/$DEPLOY_PATH/"
-          gcloud storage rsync . "gs://$GCS_BUCKET/$DEPLOY_PATH/" \
-            --recursive \
-            --delete-unmatched-destination-objects \
-            --exclude=".git*"
+          echo "Deploying to gs://$GCS_BUCKET/$DEPLOY_PATH/"
+          for item in LICENSE README.md assembly annotation typing submission; do gcloud storage cp -r "$item" "gs://$GCS_BUCKET/$DEPLOY_PATH/"; done
           echo "Deployment complete!"
 
       - name: Verify deployment


### PR DESCRIPTION
## Critical Security Fix

The previous deployment workflow accidentally deployed ALL files in the repository working directory to the public GCS bucket, including GitHub Actions temporary credential files.

## Problem
Using rsync with exclude patterns left the door open for accidentally deploying sensitive files. The workflow deployed the service account credentials JSON file that GitHub Actions creates temporarily.

## Solution
Changed from exclude-based approach to explicit include-only approach:
- **Before**: rsync with --exclude patterns (error-prone)
- **After**: Explicitly copy only intended files/directories

## Files Deployed
Only these files/directories are now deployed:
- LICENSE
- README.md
- assembly/
- annotation/
- typing/
- submission/

## Remediation Completed
✅ Exposed credentials removed from public bucket
✅ Compromised service account key deleted (cd0241c93700924350bf313f17a893cd9ecbd1df)
✅ New service account key created and deployed (592f153705d0dfc5e735be42bae17af485545726)
✅ GitHub secret GCS_DEPLOY_SA_KEY updated with new key