### PR TITLE
Add automated secrets scanning for public GCS bucket

### DIFF
--- a/.github/workflows/scan-gcs-secrets.yml
+++ b/.github/workflows/scan-gcs-secrets.yml
@@ -1,0 +1,40 @@
+name: Scan GCS Bucket for Secrets
+
+on:
+  # Trigger after deployment workflow completes
+  workflow_run:
+    workflows: ["Deploy to Google Cloud Storage"]
+    types:
+      - completed
+  # Weekly scheduled scan - Every Sunday at midnight UTC
+  schedule:
+    - cron: '0 0 * * 0'
+  # Manual trigger
+  workflow_dispatch:
+
+jobs:
+  scan-bucket:
+    name: Scan for Secrets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Download entire bucket contents (public access)
+        env:
+          GCS_BUCKET: viral-references
+        run: |
+          mkdir -p /tmp/bucket-scan
+          echo "Downloading gs://$GCS_BUCKET/ to /tmp/bucket-scan/ (using public access)"
+          gcloud storage cp -r "gs://$GCS_BUCKET/*" /tmp/bucket-scan/ --no-user-output-enabled
+          echo "Download complete. Scanning directory contents:"
+          ls -la /tmp/bucket-scan/
+
+      - name: Scan for secrets with gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITLEAKS_ENABLE_SUMMARY: true
+        with:
+          path: /tmp/bucket-scan/
+          fail: true  # Fail workflow if secrets found

--- a/.github/workflows/scan-gcs-secrets.yml
+++ b/.github/workflows/scan-gcs-secrets.yml
@@ -12,6 +12,8 @@ on:
   # Manual trigger
   workflow_dispatch:
 
+permissions: {}  # No GitHub permissions needed (workflow only accesses public GCS bucket)
+
 jobs:
   scan-bucket:
     name: Scan for Secrets

--- a/.github/workflows/validate-vadr-table.yml
+++ b/.github/workflows/validate-vadr-table.yml
@@ -9,6 +9,9 @@ on:
       - 'annotation/vadr/vadr-by-taxid.tsv'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/GCS_SECRETS_SCANNER_SETUP.md
+++ b/GCS_SECRETS_SCANNER_SETUP.md
@@ -1,0 +1,85 @@
+# GCS Secrets Scanner Setup Guide
+
+This guide documents the automated secrets scanning workflow that monitors the public GCS bucket `gs://viral-references/` for accidentally deployed credentials.
+
+## Overview
+
+The secrets scanner runs:
+- **After every deployment** (triggered automatically when the deploy workflow completes)
+- **Weekly on Sundays at midnight UTC** (scheduled cron job)
+- **On-demand** (manual trigger via GitHub Actions)
+
+## Prerequisites
+
+**None!** The bucket is public, so no authentication or service account setup is required.
+
+## Setup
+
+The workflow is ready to use immediately after merging. No additional setup steps are needed.
+
+## Verification
+
+Test the workflow after merging:
+
+1. **Manual Trigger Test**: Go to Actions tab → "Scan GCS Bucket for Secrets" → Run workflow
+2. **Verify Public Access**: Confirm the bucket is publicly accessible:
+   ```bash
+   gcloud storage ls gs://viral-references/
+   ```
+
+## Workflow Details
+
+- **Workflow File**: `.github/workflows/scan-gcs-secrets.yml`
+- **Scanner**: gitleaks v2 (GitHub Action)
+- **Scope**: Entire bucket (all paths: `main/`, version tags like `1.0.0/`, etc.)
+- **On Detection**: Workflow fails and appears in Actions tab
+- **Authentication**: None required (bucket is public)
+
+## Handling False Positives
+
+If the scanner detects false positives (e.g., high-entropy strings in TSV data files):
+
+1. Create a `.gitleaks.toml` configuration file in the repository root
+2. Add allowlist patterns for known false positives
+3. Update the workflow to use the custom config
+
+Example `.gitleaks.toml`:
+```toml
+[allowlist]
+description = "Allow high-entropy strings in TSV data files"
+paths = [
+  '''\.tsv$''',
+]
+```
+
+## Security Notes
+
+- **Public Bucket**: The bucket is already publicly readable, so no additional access is granted
+- **Ephemeral Storage**: Downloaded bucket contents are stored in GitHub runner temp directory (automatically cleaned up)
+- **Audit Trail**: All workflow runs are logged in GitHub Actions
+- **No Credentials**: No service account or credentials are used by the workflow
+
+## Troubleshooting
+
+### Workflow Fails with "Permission Denied"
+- Verify the bucket is still publicly accessible:
+  ```bash
+  gcloud storage ls gs://viral-references/
+  ```
+- If bucket permissions changed, the workflow may need to be updated to use authentication
+
+### No Scans After Deployment
+- Verify `workflow_run` trigger is configured correctly
+- Check that deploy workflow name matches: "Deploy to Google Cloud Storage"
+- Ensure the deploy workflow completed successfully
+
+### Scanner Not Running on Schedule
+- Cron schedule is in UTC (Sunday 00:00 UTC)
+- Check Actions tab for scheduled runs
+- GitHub Actions may have a delay of a few minutes for scheduled workflows
+
+## Related Documentation
+
+- [gitleaks GitHub Action](https://github.com/gitleaks/gitleaks-action)
+- [GCP Service Account Best Practices](https://cloud.google.com/iam/docs/best-practices-service-accounts)
+- [GitHub Actions workflow_run trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)


### PR DESCRIPTION
## Summary

Implements automated secrets scanning for the public GCS bucket (`gs://viral-references/`) to detect accidentally deployed credentials or secrets. Also addresses CodeQL security alerts for missing permissions blocks in GitHub Actions workflows.

## Features

### Secrets Scanning
- **Post-deployment scanning**: Runs automatically after every deployment (triggered by `workflow_run`)
- **Weekly scheduled scans**: Every Sunday at midnight UTC for ongoing monitoring
- **Manual triggers**: On-demand scans via GitHub Actions UI
- **Simple implementation**: Uses gitleaks official GitHub Action (no complex setup)
- **Comprehensive coverage**: Scans entire bucket including all paths (`main/`, version tags)
- **Immediate feedback**: Workflow fails if secrets detected (visible in Actions tab)

### Security Hardening
- **CodeQL compliance**: Added explicit `permissions` blocks to all workflows
- Fixes CodeQL security alert #1 for `validate-vadr-table.yml`
- New scanning workflow follows security best practices with minimal permissions

## Implementation Details

- **Scanner**: [gitleaks v2 GitHub Action](https://github.com/gitleaks/gitleaks-action)
- **Authentication**: None required (bucket is public)
- **Triggers**: `workflow_run`, `schedule`, `workflow_dispatch`
- **Scope**: All bucket contents downloaded to ephemeral runner storage for scanning
- **Permissions**: Minimal GITHUB_TOKEN permissions (empty for scanner, `contents: read` for validators)

## Files Modified

1. `.github/workflows/scan-gcs-secrets.yml` - New secrets scanning workflow
2. `.github/workflows/validate-vadr-table.yml` - Added permissions block
3. `GCS_SECRETS_SCANNER_SETUP.md` - Documentation and troubleshooting guide

## Testing Plan

After merge:
1. Manually trigger workflow via Actions tab to verify it works
2. Wait for next deployment to verify `workflow_run` trigger
3. Monitor for false positives (high-entropy strings in TSV data)
4. If needed, add `.gitleaks.toml` for custom allowlist rules

## Security Considerations

- Leverages existing public bucket access (no new permissions granted)
- Downloaded content stored in GitHub runner temp directory (auto-cleaned)
- All scans logged in GitHub Actions for audit trail
- Defense-in-depth: catches secrets post-deployment as additional safety net
- Explicit permissions blocks follow principle of least privilege

🤖 Generated with [Claude Code](https://claude.com/claude-code)