### PR TITLE
Fix secrets scanner to use anonymous public bucket access

### DIFF
--- a/.github/workflows/scan-gcs-secrets.yml
+++ b/.github/workflows/scan-gcs-secrets.yml
@@ -34,10 +34,14 @@ jobs:
           echo "Download complete. Scanning directory contents:"
           ls -la /tmp/bucket-scan/
 
+      - name: Install gitleaks
+        run: |
+          wget -q https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz
+          tar -xzf gitleaks_8.21.2_linux_x64.tar.gz
+          sudo mv gitleaks /usr/local/bin/
+          gitleaks version
+
       - name: Scan for secrets with gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITLEAKS_ENABLE_SUMMARY: true
-        with:
-          path: /tmp/bucket-scan/
-          fail: true  # Fail workflow if secrets found
+        run: |
+          echo "Scanning /tmp/bucket-scan/ for secrets..."
+          gitleaks detect --source /tmp/bucket-scan/ --verbose --no-git --exit-code 1

--- a/.github/workflows/scan-gcs-secrets.yml
+++ b/.github/workflows/scan-gcs-secrets.yml
@@ -26,10 +26,11 @@ jobs:
       - name: Download entire bucket contents (public access)
         env:
           GCS_BUCKET: viral-references
+          BOTO_CONFIG: /dev/null  # Disable boto config to force anonymous access
         run: |
           mkdir -p /tmp/bucket-scan
-          echo "Downloading gs://$GCS_BUCKET/ to /tmp/bucket-scan/ (using public access)"
-          gcloud storage cp -r "gs://$GCS_BUCKET/*" /tmp/bucket-scan/ --no-user-output-enabled
+          echo "Downloading gs://$GCS_BUCKET/ to /tmp/bucket-scan/ (using public anonymous access)"
+          gsutil -m cp -r "gs://$GCS_BUCKET/*" /tmp/bucket-scan/
           echo "Download complete. Scanning directory contents:"
           ls -la /tmp/bucket-scan/
 


### PR DESCRIPTION
## Summary

Fixes the secrets scanning workflow that was failing due to two issues:
1. Authentication error when accessing public bucket
2. Gitleaks GitHub Action requiring a license for organization repositories

## Problems

### Issue 1: Authentication Required
The workflow was failing with:
```
ERROR: (gcloud.storage.cp) You do not currently have an active account selected.
```

Even though `gs://viral-references/` is publicly accessible, `gcloud storage cp` requires authentication.

### Issue 2: Gitleaks Action License
After fixing authentication, the workflow failed with:
```
[broadinstitute] is an organization. License key is required.
```

The `gitleaks/gitleaks-action@v2` GitHub Action requires a paid license for organization repositories.

## Solutions

### Fix 1: Anonymous Public Access
Replaced `gcloud storage cp` with `gsutil cp`:
- Uses `gsutil -m cp -r` for parallel multi-threaded downloads
- Sets `BOTO_CONFIG=/dev/null` to force anonymous/unauthenticated access
- No authentication required

### Fix 2: Use Free Gitleaks Binary
Replaced the gitleaks GitHub Action with direct binary installation:
- Downloads gitleaks v8.21.2 binary from official GitHub releases
- Gitleaks binary is free/open-source (MIT licensed)
- Only the GitHub Action wrapper requires a license for orgs
- Runs `gitleaks detect --no-git` to scan non-git directories
- Exit code 1 ensures workflow fails if secrets detected

## Changes

`.github/workflows/scan-gcs-secrets.yml`:
1. Changed from `gcloud storage cp` to `gsutil -m cp -r`
2. Added `BOTO_CONFIG=/dev/null` environment variable
3. Replaced `uses: gitleaks/gitleaks-action@v2` with direct binary installation
4. Added gitleaks installation step (wget + tar + install)
5. Added manual gitleaks scan step with proper flags

## Testing

After merge, the workflow should run successfully on:
- Next deployment (workflow_run trigger)
- Next Sunday at midnight UTC (scheduled trigger)
- Manual trigger from Actions tab

## Cost

**$0** - Both gsutil and gitleaks binary are completely free to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)