### PR TITLE
add D8 genotype measles ref

### DIFF
--- a/assembly/reference_genomes.tsv
+++ b/assembly/reference_genomes.tsv
@@ -344,6 +344,7 @@
 289365		Human parvovirus 4	KM390024.1
 2560602		Mumps orthorubulavirus	NC_002200.1
 11234		Measles morbillivirus	NC_001498.1
+11234		Measles morbillivirus D8	PV870339.1
 11041		Rubella virus	NC_001545.2
 10497		African swine fever virus	NC_044950.1
 10497		African swine fever virus	NC_044951.1


### PR DESCRIPTION
This adds a 2025 Netherlands D8 genotype Measles reference genome in the off chance that it improves MF-NCR assembly quality/coverage. Empirical testing showed minimal differences for the same read data but we include here anyway in case.
